### PR TITLE
Add support for textures of type other than gl.UNSIGNED_BYTE

### DIFF
--- a/igloo.js
+++ b/igloo.js
@@ -144,7 +144,7 @@ Igloo.prototype.elements = function(data, usage) {
  */
 Igloo.prototype.texture = function(source, format, wrap, filter, type) {
     var texture = new Igloo.Texture(this.gl, format, wrap, filter, type);
-    if (source !== null) {
+    if (source != null) {
         texture.set(source);
     }
     return texture;

--- a/igloo.js
+++ b/igloo.js
@@ -139,11 +139,12 @@ Igloo.prototype.elements = function(data, usage) {
  * @param {GLenum} [format=GL_RGBA]
  * @param {GLenum} [wrap=GL_CLAMP_TO_EDGE]
  * @param {GLenum} [filter=GL_LINEAR]
+ * @param {GLenum} [type=UNSIGNED_BYTE]
  * @returns {Igloo.Texture}
  */
-Igloo.prototype.texture = function(source, format, wrap, filter) {
-    var texture = new Igloo.Texture(this.gl, format, wrap, filter);
-    if (source != null) {
+Igloo.prototype.texture = function(source, format, wrap, filter, type) {
+    var texture = new Igloo.Texture(this.gl, format, wrap, filter, type);
+    if (source !== null) {
         texture.set(source);
     }
     return texture;
@@ -367,9 +368,10 @@ Igloo.Buffer.prototype.update = function(data, usage) {
  * @param {GLenum} [format=GL_RGBA]
  * @param {GLenum} [wrap=GL_CLAMP_TO_EDGE]
  * @param {GLenum} [filter=GL_LINEAR]
+ * @param {GLenum} [type=UNSIGNED_BYTE]
  * @returns {Igloo.Texture}
  */
-Igloo.Texture = function(gl, format, wrap, filter) {
+Igloo.Texture = function(gl, format, wrap, filter, type) {
     this.gl = gl;
     var texture = this.texture = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, texture);
@@ -379,7 +381,8 @@ Igloo.Texture = function(gl, format, wrap, filter) {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrap);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filter);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filter);
-    this.format = format = format == null ? gl.RGBA : format;
+    this.format = format == null ? gl.RGBA : format;
+    this.type = type == null ? gl.UNSIGNED_BYTE : type;
 };
 
 /**
@@ -405,7 +408,7 @@ Igloo.Texture.prototype.blank = function(width, height) {
     var gl = this.gl;
     this.bind();
     gl.texImage2D(gl.TEXTURE_2D, 0, this.format, width, height,
-                  0, this.format, gl.UNSIGNED_BYTE, null);
+                  0, this.format, this.type, null);
     return this;
 };
 
@@ -420,14 +423,20 @@ Igloo.Texture.prototype.blank = function(width, height) {
 Igloo.Texture.prototype.set = function(source, width, height) {
     var gl = this.gl;
     this.bind();
-    if (source instanceof Array) source = new Uint8Array(source);
+    if (source instanceof Array) {
+        if (this.type == gl.FLOAT) {
+            source = new Float32Array(source);
+        } else {
+            source = new Uint8Array(source);
+        }
+    }
     if (width != null || height != null) {
         gl.texImage2D(gl.TEXTURE_2D, 0, this.format,
                       width, height, 0, this.format,
-                      gl.UNSIGNED_BYTE, source);
+                      this.type, source);
     } else {
         gl.texImage2D(gl.TEXTURE_2D, 0, this.format,
-                      this.format, gl.UNSIGNED_BYTE, source);
+                      this.format, this.type, source);
     }
     return this;
 };
@@ -444,14 +453,20 @@ Igloo.Texture.prototype.set = function(source, width, height) {
 Igloo.Texture.prototype.subset = function(source, xoff, yoff, width, height) {
     var gl = this.gl;
     this.bind();
-    if (source instanceof Array) source = new Uint8Array(source);
+    if (source instanceof Array) {
+        if (this.type == gl.FLOAT) {
+            source = new Float32Array(source);
+        } else {
+            source = new Uint8Array(source);
+        }
+    }
     if (width != null || height != null) {
         gl.texSubImage2D(gl.TEXTURE_2D, 0, xoff, yoff,
                          width, height,
-                         this.format, gl.UNSIGNED_BYTE, source);
+                         this.format, this.type, source);
     } else {
         gl.texSubImage2D(gl.TEXTURE_2D, 0, xoff, yoff,
-                         this.format, gl.UNSIGNED_BYTE, source);
+                         this.format, this.type, source);
     }
     return this;
 };


### PR DESCRIPTION
Hey Chris - this is the PR that I emailed you about. I'm building a simulation that uses float textures. I use it as follows:

```
ext = gl.getExtension("OES_texture_float")

...

myTexture = _igloo.texture(null, gl.RGBA, gl.REPEAT, gl.NEAREST, gl.FLOAT)
```

You can use `_igloo.texture` as you did before, or with `gl.UNSIGNED_BYTE` to have textures behave as they do now. This change should be 100% backward-compatible with old Igloo code.

I ran the demo in the repo and my own project as tests.
